### PR TITLE
Update PatternPack.Global.Navigation.js

### DIFF
--- a/theme-assets/js/PatternPack.Global.Navigation.js
+++ b/theme-assets/js/PatternPack.Global.Navigation.js
@@ -23,7 +23,7 @@ PatternLibrary.Global.Navigation = function() {
     }
   }
 
-  function toggleMenu() {
+  function toggleMenu(event) {
     event.preventDefault();
 
     if (_libraryContainer.classList) {


### PR DESCRIPTION
pass event as a parameter to menuToggle to fix ReferenceError: event is not defined on click.

From https://github.com/patternpack/patternpack/issues#79

skirem/patternpack#79
